### PR TITLE
Check for the child process errors the proper way

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function run () {
   debug(cmd)
   const result = execa.shellSync(cmd)
 
-  if (result.error) {
+  if (result.status !== 0) {
     console.log('Error')
     console.log('stdout:', result.stdout)
     console.log('stderr:', result.stderr)


### PR DESCRIPTION
This is the proper way to check for the errors spit by `execa`.

I had a problem with phantomjs and it was not visible when running tlapse.