### PR TITLE
Remove extra quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function run () {
   var cmd = [
     pageresPath,
     pageresOptions,
-    '--filename=\'' + Date.now() + '\''
+    '--filename=' + Date.now()
   ].join(' ')
 
   debug(cmd)


### PR DESCRIPTION
Not sure if this is intended or not, but the files get saved with quotes such as `'1488580175275'.png`

This PR removes those quotes so they are saved like `1488580175275.png`.