### PR TITLE
Save screenshots in the proper directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,9 +47,7 @@ function run () {
     '--filename=' + Date.now()
   ].join(' ')
 
-  const result = execa.shellSync(cmd, {
-    cwd: path.join(__dirname, './node_modules/.bin')
-  })
+  const result = execa.shellSync(cmd)
 
   if (result.status !== 0) {
     console.log('Error')


### PR DESCRIPTION
Setting `cwd` directory makes the pageres process save the files in `./node_modules/.bin` - which is wrong and ignores user settings.

Removing this option from shellSync call fixes the issue.