### PR TITLE
Split into multiple file, so it is possible to reuse the logic in a script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ If you want to start your server and `tlapse` at the same time, add `tlapse` to 
 }
 ```
 
+If you want to use tlaps in a start script just import `tlapse\run` and use it like this:
+
+```
+  import { runTlapse, } from 'tlapse/run'
+  // or
+  // const runTlapse = require('tlapse/run').runTlapse
+
+  runTlapse('localhost:3000', './screens', '5m')
+```
+
 ## License
 
 MIT - [Typicode :cactus:](https://github.com/typicode)

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-var run = require('./src/run').run
+var runTlapse = require('./run').runTlapse
 
 var yargs = require('yargs')
   .usage('Usage: $0 [options] -- <pageres-cli-options>')
@@ -30,4 +30,4 @@ console.log('Interval:', argv.every)
 
 var pageresOptions = argv._.join(' ')
 
-run(pageresOptions, argv.directory, argv.every)
+runTlapse(pageresOptions, argv.directory, argv.every)

--- a/index.js
+++ b/index.js
@@ -1,11 +1,5 @@
 #!/usr/bin/env node
-var fs = require('fs')
-var path = require('path')
-var mkdirp = require('mkdirp')
-var execa = require('execa')
-var ms = require('ms')
-var dateFormat = require('dateformat')
-var pageresPath = '"' + path.join(__dirname, './node_modules/.bin/pageres') + '"'
+var run = require('./src/run').run
 
 var yargs = require('yargs')
   .usage('Usage: $0 [options] -- <pageres-cli-options>')
@@ -31,54 +25,9 @@ if (argv._.length === 0) {
   process.exit(1)
 }
 
-if (argv.directory) {
-  mkdirp.sync(argv.directory)
-  process.chdir(argv.directory)
-}
-
 console.log('Screenshots directory:', argv.directory)
 console.log('Interval:', argv.every)
 
-function run () {
-  var pageresOptions = argv._.join(' ')
-  var cmd = [
-    pageresPath,
-    pageresOptions,
-    '--filename=' + Date.now()
-  ].join(' ')
+var pageresOptions = argv._.join(' ')
 
-  const result = execa.shellSync(cmd)
-
-  if (result.status !== 0) {
-    console.log('Error')
-    console.log('stdout:', result.stdout)
-    console.log('stderr:', result.stderr)
-  } else {
-    var recentFiles = fs
-      .readdirSync(process.cwd())
-      .reverse()
-
-    var latestFile = recentFiles[0]
-    var previousFile = recentFiles[1]
-    var now = dateFormat(Date.now(), 'hh:MM:ss')
-
-    if (latestFile && latestFile.indexOf('.png.') !== -1) {
-      console.log(now, '○ Can\'t connect, Skipping')
-      return fs.unlinkSync(latestFile)
-    }
-
-    if (
-      latestFile &&
-      previousFile &&
-      fs.readFileSync(latestFile, 'utf-8') === fs.readFileSync(previousFile, 'utf-8')
-    ) {
-      console.log(now, '○ Duplicate screenshot, skipping')
-      return fs.unlinkSync(latestFile)
-    }
-
-    console.log(now, result.stdout.trim())
-  }
-}
-
-run()
-setInterval(run, ms(argv.every))
+run(pageresOptions, argv.directory, argv.every)

--- a/run.js
+++ b/run.js
@@ -5,9 +5,9 @@ var mkdirp = require('mkdirp')
 var execa = require('execa')
 var ms = require('ms')
 
-var pageresPath = '"' + path.join(__dirname, '../node_modules/.bin/pageres') + '"'
+var pageresPath = '"' + path.join(__dirname, './node_modules/.bin/pageres') + '"'
 
-function run (pageresOptions, directory, every) {
+function runTlapse (pageresOptions, directory, every) {
   if (directory) {
     mkdirp.sync(directory)
     process.chdir(directory)
@@ -54,4 +54,4 @@ function takeScreenshot (pageresOptions) {
   }
 }
 
-module.exports = { run: run, takeScreenshot: takeScreenshot }
+module.exports = { runTlapse: runTlapse, takeScreenshot: takeScreenshot }

--- a/run.js
+++ b/run.js
@@ -16,7 +16,7 @@ function runTlapse (pageresOptions, directory, every) {
   const exec = () => takeScreenshot(pageresOptions)
 
   exec()
-  setInterval(() => exec, ms(every))
+  setInterval(() => exec, ms(every || '1m'))
 }
 
 function takeScreenshot (pageresOptions) {

--- a/src/run.js
+++ b/src/run.js
@@ -1,0 +1,57 @@
+var dateFormat = require('dateformat')
+var fs = require('fs')
+var path = require('path')
+var mkdirp = require('mkdirp')
+var execa = require('execa')
+var ms = require('ms')
+
+var pageresPath = '"' + path.join(__dirname, '../node_modules/.bin/pageres') + '"'
+
+function run (pageresOptions, directory, every) {
+  if (directory) {
+    mkdirp.sync(directory)
+    process.chdir(directory)
+  }
+
+  const exec = () => takeScreenshot(pageresOptions)
+
+  exec()
+  setInterval(() => exec, ms(every))
+}
+
+function takeScreenshot (pageresOptions) {
+  var cmd = [pageresPath, pageresOptions, '--filename=' + Date.now()].join(' ')
+
+  const result = execa.shellSync(cmd)
+
+  if (result.status !== 0) {
+    console.log('Error')
+    console.log('stdout:', result.stdout)
+    console.log('stderr:', result.stderr)
+  } else {
+    var recentFiles = fs.readdirSync(process.cwd()).reverse()
+
+    var latestFile = recentFiles[0]
+    var previousFile = recentFiles[1]
+    var now = dateFormat(Date.now(), 'hh:MM:ss')
+
+    if (latestFile && latestFile.indexOf('.png.') !== -1) {
+      console.log(now, "○ Can't connect, Skipping")
+      return fs.unlinkSync(latestFile)
+    }
+
+    if (
+      latestFile &&
+      previousFile &&
+      fs.readFileSync(latestFile, 'utf-8') ===
+        fs.readFileSync(previousFile, 'utf-8')
+    ) {
+      console.log(now, '○ Duplicate screenshot, skipping')
+      return fs.unlinkSync(latestFile)
+    }
+
+    console.log(now, result.stdout.trim())
+  }
+}
+
+module.exports = { run: run, takeScreenshot: takeScreenshot }


### PR DESCRIPTION
This PR takes out the run logic into a separate function that does not use `argv`, it makes it easier to reuse the logic in custom scripts.