### PR TITLE
tolerate bad ssl certificates

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,10 @@ module.exports = async function(argv) {
   )
   console.log(chalk.gray('URL'), argv._[0])
 
-  const browser = await puppeteer.launch()
+  const browser = await puppeteer.launch({
+    ignoreHTTPSErrors: true,
+    args:['--ignore-certificate-errors', '--enable-feature=NetworkService']
+  })
   const page = await browser.newPage()
 
   page.setViewport({


### PR DESCRIPTION
very often, lazy developers use self-signed certificates for their local / staging / integration environments, who are we to blame them ?